### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,14 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
   - hhvm
   - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,13 @@
     "config-dir": "config"
   },
   "autoload": {
-    "psr-0": {
-      "": "src/"
+    "psr-4": {
+      "TixAstronauta\\AccIp\\": "src/TixAstronauta/AccIp"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "TixAstronauta\\AccIp\\Tests\\": "tests"
     }
   },
   "authors": [
@@ -31,6 +36,6 @@
     "php": ">=5.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*"
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,4 +9,9 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/AccIpTest.php
+++ b/tests/AccIpTest.php
@@ -24,7 +24,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-class AccIpTest extends PHPUnit_Framework_TestCase
+namespace TixAstronauta\AccIp\Test;
+
+use PHPUnit\Framework\TestCase;
+
+class AccIpTest extends TestCase
 {
     /**
      * @dataProvider serverEnvironmentGood


### PR DESCRIPTION
# Changed log
- Add the `php-7.1` and `php-7.2` tests in Travis CI build.
- Let the `php-nightly` allow to be failed because nobody can guarantee this test will be successful every time.
- Using the `psr-4` autoloader instead of the `psr-0` autoloader.
- Set the multiple PHPUnit versions for supporting different PHP versions.
- Add the filter white lists configuration in `phpunit.xml` file for covering targeted `src` classes.